### PR TITLE
Origin/v2.6.x develop

### DIFF
--- a/adapter/config/sites/open/ver_settings.py
+++ b/adapter/config/sites/open/ver_settings.py
@@ -33,16 +33,15 @@ from . import api as ADAPTER_API  # noqa
 ESB_SDK_NAME = 'blueking.component.open'
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.mysql',
-        'NAME': os.environ.get('BKAPP_DB_TEST'),
-        'USER': os.environ.get('BKAPP_MYSQL_USER'),
-        'PASSWORD': os.environ.get('BKAPP_MYSQL_PASS'),
-        'HOST': os.environ.get('BKAPP_MYSQL_IP'),
-        'PORT': os.environ.get('BKAPP_MYSQL_PORT'),
+    "default": {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": os.environ.get("DB_NAME"),
+        "USER": os.environ.get("DB_USER"),
+        "PASSWORD": os.environ.get("DB_PASSWORD"),
+        "HOST": os.environ.get("DB_HOST"),
+        "PORT": os.environ.get("DB_PORT"),
     },
 }
-
 STORE = FileSystemStorage(location='/')
 
 # 企业微信发送，默认weixin，可配置为企业微信rtx

--- a/config/prod.py
+++ b/config/prod.py
@@ -51,11 +51,11 @@ DATABASES.update(
     {
         "default": {
             "ENGINE": "django.db.backends.mysql",
-            "NAME": os.environ.get("BKAPP_DB_TEST"),
-            "USER": os.environ.get("BKAPP_MYSQL_USER"),
-            "PASSWORD": os.environ.get("BKAPP_MYSQL_PASS"),
-            "HOST": os.environ.get("BKAPP_MYSQL_IP"),
-            "PORT": os.environ.get("BKAPP_MYSQL_PORT"),
+            "NAME": os.environ.get("DB_NAME"),
+            "USER": os.environ.get("DB_USER"),
+            "PASSWORD": os.environ.get("DB_PASSWORD"),
+            "HOST": os.environ.get("DB_HOST"),
+            "PORT": os.environ.get("DB_PORT"),
         },
     }
 )

--- a/config/stag.py
+++ b/config/stag.py
@@ -49,11 +49,11 @@ DATABASES.update(
     {
         "default": {
             "ENGINE": "django.db.backends.mysql",
-            "NAME": os.environ.get("BKAPP_DB_TEST"),
-            "USER": os.environ.get("BKAPP_MYSQL_USER"),
-            "PASSWORD": os.environ.get("BKAPP_MYSQL_PASS"),
-            "HOST": os.environ.get("BKAPP_MYSQL_IP"),
-            "PORT": os.environ.get("BKAPP_MYSQL_PORT"),
+            "NAME": os.environ.get("DB_NAME"),
+            "USER": os.environ.get("DB_USER"),
+            "PASSWORD": os.environ.get("DB_PASSWORD"),
+            "HOST": os.environ.get("DB_HOST"),
+            "PORT": os.environ.get("DB_PORT"),
         },
     }
 )

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,7 +3,92 @@
 # 需要额外的python包，可直接在文件后面添加
 # 请确保指定的包和版本号，可通过pip安装
 
--r requirements.txt
+# windows平台无法使用这个参数，直接把依赖包拷贝过来
+# -r requirements.txt
+
+# blueapps requirement
+Django==3.2.4
+PyMySQL==0.6.7
+mysqlclient==2.0.3
+# 由于setuptools 版本过高无法安装低版本的 MarkupSage 由1.0 -> 2.0.1
+# MarkupSafe==2.0.1
+Mako==1.0.6
+requests==2.23.0
+celery==4.4.5
+django-celery-beat==2.0.0
+django-celery-results==2.0.0
+# pi==3.3.1
+python-json-logger==0.1.7
+whitenoise==3.3.0
+six==1.16.0
+httplib2==0.9.1
+djangorestframework==3.12.4
+drf-extensions==0.7.0
+django-cors-headers==3.7.0
+jsonfield==3.1.0
+pypinyin==0.31.0
+django_extensions==2.1.0
+django-filter==2.4.0
+# django-autofixture==0.12.1
+django-revproxy==0.10.0
+pyinstrument_cext==0.2.2
+pyinstrument==3.0.3
+humanize==0.5.1
+xlwt==1.3.0
+jsonschema==3.2.0
+# django-smart-autoregister==0.0.5
+django-bulk-update==2.2.0
+django-redis==5.0.0
+RestrictedPython==5.0
+
+# wiki related
+bleach==1.5.0
+django-classy-tags==2.0.0
+django-mptt==0.12.0
+django-mptt-admin==2.1.0
+django-nyt==1.2
+django-sekizai==2.0.0
+Markdown==2.6.11
+Pillow==5.2.0
+sorl-thumbnail==12.7.0
+django-simplemde==0.1.2
+martor==1.2.8
+python-dateutil==2.7.5
+django-multiselectfield==0.1.12
+
+# monitor
+statsd==3.3.0
+
+# pipeline
+ujson==1.35
+pyparsing==2.2.0
+redis==3.5.3
+redis-py-cluster==2.1.3
+django-timezone-field==4.1.2
+factory_boy==2.11.1
+mistune==0.8.4
+eventlet==0.25.1
+gevent==1.2.2
+
+# iam
+cachetools==3.1.1
+certifi==2020.4.5.1
+chardet==3.0.4
+curlify==2.2.1
+idna==2.9
+urllib3==1.25.9
+# 这个依赖包名字总是变化也不适用于windows平台 由pycrypto==2.6.1 -> 改为pycryptodome==3.11.0
+pycryptodome==3.11.0
+
+# excel
+xlrd==1.2.0
+typing_extensions==3.6.5
+
+# setuptools 版本太高无法安装 建议升级版本由 0.3.3 -> 1.35
+anyjson==1.35
+
+#bkouth
+PyJWT==2.1.0 
 
 # 本地开发
 isort==4.3.4


### PR DESCRIPTION
在蓝鲸社区版6.0.4上做bk_itsm的升级，在本地做itsm编译以及smart部署过程中遇到几个问题

- 安装开发环境依赖包过程中 requirement.dev.txt不支持 -r requirements.txt 这个参数 
- 安装依赖包时候，有三个包不支持高版本setuptools，其中有一个依赖包已经换名字了

**当然：生产环境的依赖包还需要pip download requirements.txt中的包，又或者可以直接替换更换后的依赖包**