### PR TITLE
feat:all state_processors can view ticket

### DIFF
--- a/itsm/ticket/models/ticket.py
+++ b/itsm/ticket/models/ticket.py
@@ -2245,8 +2245,10 @@ class Ticket(Model, BaseTicket):
 
     def can_view(self, username):
         """能否查看单据"""
+        all_state_processors = list(set([user for users in self.meta.get("state_processors",{}).values() for user in users.split(',')]))
         if (
-            dotted_name(username) in self.updated_by
+            username in all_state_processors
+            or dotted_name(username) in self.updated_by
             or username in self.task_operators
             or self.can_operate(username)
             or AttentionUsers.objects.filter(


### PR DESCRIPTION
通过接口发起的ticket，用state_processor添加的各个阶段的审批人，目前在审批结束以后都没权限查看ticket，只有最后修改人和创建人，以及IAM的权限用户可以查看，这不太合理。

有审批权限的人即使工单结束也应该可以查看工单